### PR TITLE
Take out postRemove/postDestroy alias

### DIFF
--- a/lib/remove-handler.js
+++ b/lib/remove-handler.js
@@ -50,11 +50,7 @@ internals.optionsSchema = function (sequelize) {
         options: joi.object().default({}),
         preRemove: joi.func().default(internals.defaultPreDelete),
         postRemove: joi.func().default(internals.defaultPostDelete)
-    })
-        .rename('preDestroy', 'preRemove', { multiple: true })
-        .rename('preDelete', 'preRemove', { multiple: true })
-        .rename('postDestroy', 'postRemove', { multiple: true })
-        .rename('postDelete', 'postRemove', { multiple: true });
+    });
 };
 
 /**


### PR DESCRIPTION
Alias causes failure on launch for routes that use postRemove