### PR TITLE
pure node streams, fixed COPY stream hanging on immediate source stream error

### DIFF
--- a/lib/bulk-upsert-plugin.js
+++ b/lib/bulk-upsert-plugin.js
@@ -3,7 +3,6 @@
 const Sequelize = require('sequelize');
 const _ = require('lodash');
 const es = require('ent-streams');
-const $ = require('highland');
 const stream = require('stream');
 const util = require('util');
 const pgCopyStreams = require('pg-copy-streams');
@@ -11,8 +10,9 @@ const pgCopyStreams = require('pg-copy-streams');
 exports.plugin = {
     bulkUpsertStream ($stream, options) {
         const P = Sequelize.Promise;
+        let proceed = true;
 
-        if (!$stream || (!($stream instanceof stream.Readable) && !$.isStream($stream) && !_.isArray($stream))) return P.reject(new Error(`Cannot use Model.bulkUpsertStream() with a non-existing value or with a value that is not a Readable/Highland stream or an Array`));
+        if (!$stream || (!($stream instanceof stream.Readable) && !_.isArray($stream))) return P.reject(new Error(`Cannot use Model.bulkUpsertStream() with a non-existing value or with a value that is not a Readable/Highland stream or an Array`));
         if (_.isArray($stream) && !$stream.length) return P.resolve(this);
 
         options = _.assign({ omit: [], idFields: ['id'] }, options);
@@ -60,7 +60,8 @@ exports.plugin = {
         };
 
         // create stream-copy target temp table
-        const createTempTable = conn => P.resolve(query(conn, `CREATE TEMP TABLE "${tempTableName}" (LIKE "${this.tableName}" INCLUDING DEFAULTS) ON COMMIT DROP`));
+        const createTempTable = conn => P.resolve(proceed).then(() => query(conn, `CREATE TEMP TABLE "${tempTableName}" (LIKE "${this.tableName}" INCLUDING DEFAULTS) ON COMMIT DROP`));
+        const createCopyStream = conn => P.resolve(proceed).then(() => query(conn, pgCopyStreams.from(`COPY "${tempTableName}" (${insertColumns}) FROM STDIN WITH (FORMAT csv)`)));
 
         // build model instance from record so validation & hooks fire
         const buildInstance = record => {
@@ -109,36 +110,39 @@ exports.plugin = {
             }
         };
 
-        // build csv stream
-        const getCsvStream = () => $($stream)
-        // build model instances so hooks & validations happen
-            .map(record => buildInstance(record))
-            // Recreate record from instances to represent any changes made in hooks or validation, remove virtual attributes
-            .map(instance => _.omit(instance.dataValues, this._virtualAttributes))
-            // Map field names to column names
-            .tap(rec => ensureFields(rec))
-            // ensure record has a value for all attributes
-            .map(rec => ensureCsvRecordValues(rec, attrsForInsert))
-            // CSV-ify the record. make sure attributes are ordered properly
-            .through(es.csv({ sendHeaders: false, headers: _.pluck(attrsForInsert, 'field') }))
-            .through(es.stringify());
+        const streamError = err => _.set(err, '_streamError', true);
 
-        // stream-copy csv stream -> temp table
-        const streamCopy = conn => new P((resolve, reject) => {
-            const $copy = query(conn, pgCopyStreams.from(`COPY "${tempTableName}" (${insertColumns}) FROM STDIN WITH (FORMAT csv)`));
-            getCsvStream()
-                .pipe($copy)
-                .on('error', err => reject(err))
-                .on('end', () => resolve());
-        });
+        // build csv stream
+        const getCsvStream = ($source, $target) => es.pipeline($source,
+            // build model instances so hooks & validations happen
+            es.mapSync(record => buildInstance(record)),
+            // Recreate record from instances to represent any changes made in hooks or validation, remove virtual attributes
+            es.mapSync(instance => _.omit(instance.dataValues, this._virtualAttributes)),
+            // Map field names to column names
+            es.eachSync(rec => ensureFields(rec)),
+            // ensure record has a value for all attributes
+            es.mapSync(rec => ensureCsvRecordValues(rec, attrsForInsert)),
+            // CSV-ify the record. make sure attributes are ordered properly
+            es.csv({ sendHeaders: false, headers: _.pluck(attrsForInsert, 'field') }),
+            es.stringify(),
+            $target);
+
+        // // stream-copy csv stream -> temp table
+        const streamCopy = (conn, $copy) => P.resolve(proceed)
+            .then(() => new P((resolve, reject) => {
+                getCsvStream($stream, $copy)
+                    .on('error', err => reject(streamError(err)))
+                    .on('end', () => resolve());
+            }))
+            .finally(() => $copy.end());
 
         // INSERT INTO <model>(<insertColumns>) SELECT <insertColumns> FROM <foreignTable> ON CONFLICT (<primaryKeyColumns>) DO UPDATE SET (<nonConstraintColumns>) = (EXCLUDED.<nonConstraintColumns>)
-        const insertOnConflict = conn => P.resolve(query(conn, `INSERT INTO "${this.tableName}"(${insertColumns}) SELECT ${insertColumns} FROM ${tempTableName} ON CONFLICT (${onConflictColumns}) DO UPDATE SET (${lhsUpdateColumns}) = (${rhsUpdateColumns})`));
+        const insertOnConflict = conn => P.resolve(proceed).then(() => query(conn, `INSERT INTO "${this.tableName}"(${insertColumns}) SELECT ${insertColumns} FROM ${tempTableName} ON CONFLICT (${onConflictColumns}) DO UPDATE SET (${lhsUpdateColumns}) = (${rhsUpdateColumns})`));
 
         // get connection off of current transaction or from connection manager
         const getConnection = () => {
             let conn;
-            return new P(resolve => P.resolve()
+            return new P(resolve => P.resolve(proceed)
                 .then(() => _.get(options, ['transaction', 'connection']) || this.sequelize.connectionManager.getConnection(options))
                 .tap(c => conn = c)
                 .then(resolve))
@@ -149,13 +153,16 @@ exports.plugin = {
                 });
         };
 
-        const formatError = (err, conn) => {
-            return P.reject((new this.sequelize.dialect.Query(conn, this.sequelize, _.merge(options, { raw: true }))).formatError(err));
-        };
+        // format non-source stream errors with sequelize dialect. forward other errors
+        const formatError = (err, conn) => P.reject(!!err._streamError ? err : (new this.sequelize.dialect.Query(conn, this.sequelize, _.merge(options, { raw: true }))).formatError(err));
 
-        return P.using(getConnection(), conn => P.resolve()
+        $stream = es.streamify($stream)
+            .on('error', err => proceed = P.reject(streamError(err)));
+
+        return P.using(getConnection(), conn => P.resolve(proceed)
             .tap(() => createTempTable(conn))
-            .tap(() => streamCopy(conn))
+            .then(() => createCopyStream(conn))
+            .tap($copy => streamCopy(conn, $copy))
             .then(() => insertOnConflict(conn))
             .catch(err => formatError(err, conn)));
     },

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "ent-streams": "^1.11.0",
     "ent-utils": "^4.4.0",
     "glib": "^1.0.0",
-    "highland": "^2.11.1",
     "joi": "^9.0.4",
     "lodash": "^3.9.3",
     "moniker": "^0.1.2",

--- a/test/lib/bulk-upsert-plugin-spec.js
+++ b/test/lib/bulk-upsert-plugin-spec.js
@@ -8,9 +8,9 @@ const TestBlah = common.models.TestBlah;
 const sequelize = common.sequelize;
 const DataTypes = sequelize.Sequelize;
 const should = common.should;
-const $ = require('highland');
 const _ = require('lodash');
 const stream = require('stream');
+const es = require('ent-streams');
 const P = sequelize.Sequelize.Promise;
 
 describe('bulk upsert plugin', function () {
@@ -27,12 +27,6 @@ describe('bulk upsert plugin', function () {
 
         it('should reject attemps to bulk upsert a non-Readable stream', function () {
             return Foo.bulkUpsertStream(new stream.Writable()).should.be.rejectedWith(Error);
-        });
-
-        it('should reject attempts to bulk upsert a non-Highland stream', function () {
-            const badHighland = $();
-            badHighland.__HighlandStream__ = false;
-            return Foo.bulkUpsertStream(badHighland).should.be.rejectedWith(Error);
         });
 
         it('should reject attempts to bulk upsert a non-Array object', function () {
@@ -75,7 +69,7 @@ describe('bulk upsert plugin', function () {
                 immutableAttr: `immutable value ${n}`,
                 name: `My Foo ${n}`
             }));
-            const $stream = $(defns);
+            const $stream = es.readArray(defns);
             return sequelize.requiresTransaction(t => Foo.bulkUpsertStream($stream, {
                 omit: ['_changes'],
                 transaction: t
@@ -96,7 +90,7 @@ describe('bulk upsert plugin', function () {
         });
 
         it('should update from a stream', function () {
-            const $records = $([{
+            const $records = es.readArray([{
                 id: 'foo',
                 immutableAttr: 'asdf',
                 name: 'My Foo'
@@ -174,7 +168,7 @@ describe('bulk upsert plugin', function () {
         });
 
         it('should insert and update from a stream', function () {
-            const $records = $([
+            const $records = es.readArray([
                 { id: 'bar', immutableAttr: 'aaa', name: 'Bar' },
                 { id: 'foo', immutableAttr: 'zzz', name: 'Upserted Foo' },
                 { id: 'baz', immutableAttr: 'bbb', name: 'BAZZZZZ' }
@@ -245,84 +239,6 @@ describe('bulk upsert plugin', function () {
                 });
         });
 
-        it('should not do anything to the database if an error occurs', function () {
-            let upsertError;
-            const $records = $([{
-                id: 'foo',
-                immutableAttr: 'asdf',
-                name: 'My Foo'
-            },
-                {
-                    id: 'foo',
-                    immutableAttr: 'this wont be a value',
-                    name: 'FOO'
-                }]);
-            return Foo.create({
-                id: 'foo',
-                immutableAttr: 'Foo\'s immutable value',
-                name: 'Foo'
-            })
-                .then(() => Foo.bulkUpsertStream($records, { omit: ['_changes'] }))
-                .catch(err => upsertError = err)
-                .finally(() => {
-                    should.exist(upsertError);
-                    return Foo.findAll()
-                        .then(foos => {
-                            foos.should.have.length(1);
-                            _.first(foos).id.should.equal('foo');
-                            _.first(foos).immutableAttr.should.equal(`Foo's immutable value`);
-                            _.first(foos).name.should.equal('Foo');
-                        });
-                });
-        });
-
-        it('should not prevent further interaction if an error occurs', function () {
-            const badRecords = [
-                { id: 'bar', immutableAttr: 'aaa', name: 'Bar' },
-                { id: 'bar', immutableAttr: 'aaaaaa', name: 'BarBar' }
-            ];
-            const goodRecords = [
-                { id: 'bar', immutableAttr: 'aaa', name: 'BAR' },
-                { id: 'foo', immutableAttr: 'aaaaaa', name: 'FOOFOO' }
-            ];
-            let badRecErr, goodRecErr;
-            return Foo.create({
-                id: 'foo',
-                immutableAttr: 'immutable',
-                name: 'Foo'
-            })
-                .then(() => sequelize.requiresTransaction(t => Foo.bulkUpsertStream(badRecords, {
-                    omit: ['_changes'],
-                    transaction: t
-                })))
-                .catch(err => {
-                    badRecErr = err;
-                    return sequelize.requiresTransaction(t => Foo.bulkUpsertStream(goodRecords, {
-                        omit: ['_changes'],
-                        transaction: t
-                    }))
-                        .catch(err => goodRecErr = err);
-                })
-                .finally(() => {
-                    should.exist(badRecErr);
-                    should.not.exist(goodRecErr);
-                    return Foo.findAll()
-                        .then(foos => {
-                            foos.should.have.length(2);
-                            _.forEach(foos, foo => {
-                                ['foo', 'bar'].should.include(foo.id);
-                                if (foo.id === 'foo') {
-                                    foo.name.should.equal('FOOFOO');
-                                    foo.immutableAttr.should.equal('aaaaaa');
-                                } else {
-                                    foo.name.should.equal('BAR');
-                                    foo.immutableAttr.should.equal('aaa');
-                                }
-                            });
-                        });
-                });
-        });
-
         it('should always add timestamp attribute values to records if a model has timestamp fields', function () {
             const records = [{ id: 'bar', name: 'Bar', birthday: new Date() }, {
                 id: 'foo',
@@ -338,31 +254,6 @@ describe('bulk upsert plugin', function () {
                         should.exist(bar.createdAt);
                         should.exist(bar.updatedAt);
                     });
-                });
-        });
-
-        it('should not prevent further interaction if a constraint violation occurs', function () {
-            let error;
-            const records = [{ id: 'bar', name: 'Bar' }, { id: 'foo', name: 'Foo' }];
-            return sequelize.requiresTransaction(t => Bar.bulkUpsertStream(records, { transaction: t }))
-                .then(() => should.not.exist(`should not succeed`))
-                .catch(err => error = err)
-                .finally(() => {
-                    let secondError;
-                    should.exist(error);
-                    return sequelize.requiresTransaction(t => Bar.bulkUpsertStream(_.map(records, r => _.set(r, 'birthday', new Date())), { transaction: t }))
-                        .then(() => Bar.findAll())
-                        .then(bars => {
-                            should.exist(bars);
-                            bars.should.have.length(2);
-                            _.every(bars, bar => {
-                                should.exist(bar.createdAt);
-                                should.exist(bar.updatedAt);
-                                should.exist(bar.birthday);
-                            });
-                        })
-                        .catch(err => secondError = err)
-                        .finally(() => should.not.exist(secondError));
                 });
         });
 
@@ -444,27 +335,206 @@ describe('bulk upsert plugin', function () {
                     .finally(() => should.not.exist(error)));
         });
 
-        it('should forward errors that occur to the dialect for formatting & packaging', function () {
-            const ensure = (Model, rec) => P.resolve()
-                .then(() => {
-                    const instance = Model.build(rec);
-                    instance.set({ parentId: 1 });
-                    return instance.get();
+        describe('errors', function () {
+            it('should not do anything to the database if an error occurs', function () {
+                let upsertError;
+                const $records = es.readArray([{
+                    id: 'foo',
+                    immutableAttr: 'asdf',
+                    name: 'My Foo'
+                },
+                    {
+                        id: 'foo',
+                        immutableAttr: 'this wont be a value',
+                        name: 'FOO'
+                    }]);
+                return Foo.create({
+                    id: 'foo',
+                    immutableAttr: 'Foo\'s immutable value',
+                    name: 'Foo'
                 })
-                .then(recs => [].concat(recs || []));
-
-            const bazRecordsNoOptional = () => ensure(TestBaz, { bazId: 'myBaz' });
-            const blahRecordsOptional = () => ensure(TestBlah, {
-                optionalId: 'myOptional',
-                bazId: 'myBaz',
-                blahId: 'myBlah'
+                    .then(() => Foo.bulkUpsertStream($records, { omit: ['_changes'] }))
+                    .catch(err => upsertError = err)
+                    .finally(() => {
+                        should.exist(upsertError);
+                        return Foo.findAll()
+                            .then(foos => {
+                                foos.should.have.length(1);
+                                _.first(foos).id.should.equal('foo');
+                                _.first(foos).immutableAttr.should.equal(`Foo's immutable value`);
+                                _.first(foos).name.should.equal('Foo');
+                            });
+                    });
             });
 
-            return P.resolve()
-                .then(() => sequelize.requiresTransaction(t => bazRecordsNoOptional().then(recs => TestBaz.bulkUpsertStream(recs, { transaction: t }))))
-                .then(() => sequelize.requiresTransaction(t => blahRecordsOptional().then(recs => TestBlah.bulkUpsertStream(recs, { transaction: t }))))
-                .should.eventually.be.rejectedWith(sequelize.ForeignKeyConstraintError);
+            it('should not prevent further interaction if an error occurs', function () {
+                const badRecords = [
+                    { id: 'bar', immutableAttr: 'aaa', name: 'Bar' },
+                    { id: 'bar', immutableAttr: 'aaaaaa', name: 'BarBar' }
+                ];
+                const goodRecords = [
+                    { id: 'bar', immutableAttr: 'aaa', name: 'BAR' },
+                    { id: 'foo', immutableAttr: 'aaaaaa', name: 'FOOFOO' }
+                ];
+                let badRecErr, goodRecErr;
+                return Foo.create({
+                    id: 'foo',
+                    immutableAttr: 'immutable',
+                    name: 'Foo'
+                })
+                    .then(() => sequelize.requiresTransaction(t => Foo.bulkUpsertStream(badRecords, {
+                        omit: ['_changes'],
+                        transaction: t
+                    })))
+                    .catch(err => {
+                        badRecErr = err;
+                        return sequelize.requiresTransaction(t => Foo.bulkUpsertStream(goodRecords, {
+                            omit: ['_changes'],
+                            transaction: t
+                        }))
+                            .catch(err => goodRecErr = err);
+                    })
+                    .finally(() => {
+                        should.exist(badRecErr);
+                        should.not.exist(goodRecErr);
+                        return Foo.findAll()
+                            .then(foos => {
+                                foos.should.have.length(2);
+                                _.forEach(foos, foo => {
+                                    ['foo', 'bar'].should.include(foo.id);
+                                    if (foo.id === 'foo') {
+                                        foo.name.should.equal('FOOFOO');
+                                        foo.immutableAttr.should.equal('aaaaaa');
+                                    } else {
+                                        foo.name.should.equal('BAR');
+                                        foo.immutableAttr.should.equal('aaa');
+                                    }
+                                });
+                            });
+                    });
+            });
+
+            it('should not prevent further interaction if a constraint violation occurs', function () {
+                let error;
+                const records = [{ id: 'bar', name: 'Bar' }, { id: 'foo', name: 'Foo' }];
+                return sequelize.requiresTransaction(t => Bar.bulkUpsertStream(records, { transaction: t }))
+                    .then(() => should.not.exist(`should not succeed`))
+                    .catch(err => error = err)
+                    .finally(() => {
+                        let secondError;
+                        should.exist(error);
+                        return sequelize.requiresTransaction(t => Bar.bulkUpsertStream(_.map(records, r => _.set(r, 'birthday', new Date())), { transaction: t }))
+                            .then(() => Bar.findAll())
+                            .then(bars => {
+                                should.exist(bars);
+                                bars.should.have.length(2);
+                                _.every(bars, bar => {
+                                    should.exist(bar.createdAt);
+                                    should.exist(bar.updatedAt);
+                                    should.exist(bar.birthday);
+                                });
+                            })
+                            .catch(err => secondError = err)
+                            .finally(() => should.not.exist(secondError));
+                    });
+            });
+
+            it('should forward db-related writing errors that occur to the dialect for formatting & packaging', function () {
+                const ensure = (Model, rec) => P.resolve()
+                    .then(() => {
+                        const instance = Model.build(rec);
+                        instance.set({ parentId: 1 });
+                        return instance.get();
+                    })
+                    .then(recs => [].concat(recs || []));
+
+                const bazRecordsNoOptional = () => ensure(TestBaz, { bazId: 'myBaz' });
+                const blahRecordsOptional = () => ensure(TestBlah, {
+                    optionalId: 'myOptional',
+                    bazId: 'myBaz',
+                    blahId: 'myBlah'
+                });
+
+                return P.resolve()
+                    .then(() => sequelize.requiresTransaction(t => bazRecordsNoOptional().then(recs => TestBaz.bulkUpsertStream(recs, { transaction: t }))))
+                    .then(() => sequelize.requiresTransaction(t => blahRecordsOptional().then(recs => TestBlah.bulkUpsertStream(recs, { transaction: t }))))
+                    .should.eventually.be.rejectedWith(sequelize.ForeignKeyConstraintError);
+            });
+
+            it('should fail properly if the source stream errors initially during an upstream piped-to transform', function () {
+                // this.timeout(5000);
+                class InStreamError extends Error {
+                    constructor (message) {
+                        super(message);
+                        this.name = 'InStreamError';
+                    }
+                }
+                const $stream = new stream.Transform({ objectMode: true });
+                $stream._transform = function (rec, end, next) {
+                    next(new InStreamError('Error while streaming'));
+                };
+                const $source = new stream.PassThrough({ objectMode: true });
+                return P.resolve()
+                    .then(() => sequelize.requiresTransaction(t => {
+                        setTimeout(() => $source.write('foo'), 100);
+                        return TestBaz.bulkUpsertStream($source.pipe($stream), { transaction: t });
+                    }))
+                    .then(() => should.not.exist(`should not succeed`))
+                    .finally(() => TestBaz.findAll()
+                        .then(bazz => bazz.should.have.length(0)))
+                    .should.eventually.be.rejectedWith(InStreamError);
+            });
+
+            it('should properly fail if the source record stream immediately emits an error', function () {
+                // this.timeout(5000);
+                class InStreamError extends Error {
+                    constructor (message) {
+                        super(message);
+                        this.name = 'InStreamError';
+                    }
+                }
+                const $stream = new stream.Readable({ objectMode: true });
+                $stream._read = function () {
+                    this.emit('error', new InStreamError('Error while streaming'));
+                };
+
+                return P.resolve()
+                    .then(() => sequelize.requiresTransaction(t => TestBaz.bulkUpsertStream($stream, { transaction: t })))
+                    .then(() => should.not.exist(`should not succeed`))
+                    .finally(() => TestBaz.findAll()
+                        .then(bazz => bazz.should.have.length(0)))
+                    .should.eventually.be.rejectedWith(InStreamError);
+            });
+
+            it('should properly fail if the source record stream emits an error later', function () {
+                // this.timeout(5000);
+                class InStreamError extends Error {
+                    constructor (message) {
+                        super(message);
+                        this.name = 'InStreamError';
+                    }
+                }
+                const recs = [
+                    { id: 'bar', immutableAttr: 'aaa', name: 'Bar' },
+                    { id: 'foo', immutableAttr: 'zzz', name: 'Upserted Foo' }
+                ];
+                const $stream = new stream.Readable({ objectMode: true });
+                $stream._read = function () {
+                    if (recs.length) {
+                        return this.push(recs.pop());
+                    } else {
+                        setTimeout(() => this.emit('error', new InStreamError('Error while streaming')), 500);
+                    }
+                };
+                return P.resolve()
+                    .then(() => sequelize.requiresTransaction(t => Foo.bulkUpsertStream($stream, { transaction: t })))
+                    .then(() => should.not.exist(`should not succeed`))
+                    .finally(() => Foo.findAll()
+                        .then(foos => foos.should.have.length(0)))
+                    .should.eventually.be.rejectedWith(InStreamError);
+            });
         });
+
     });
 
     describe('.bulkUpsert()', function () {


### PR DESCRIPTION
- removed using highland in favor of pure node streams for streamed bulk upsert
- fixed upsert stream issue where an error emitted immediately from the source stream would cause the COPY stream to not end and hang out in the ether
- adjusted tests