### PR TITLE
i5-3980 Changes to _changes

### DIFF
--- a/lib/bulk-upsert-plugin.js
+++ b/lib/bulk-upsert-plugin.js
@@ -47,7 +47,11 @@ exports.plugin = {
         // for ON CONFLICT DO UPDATE SET (a,b,c) = (x,y,z) ... kick out: explicitly omitted via options, primary key, "createdAt"
         const attrsForUpdate = _.filter(attributes, attr => options.omit.indexOf(attr.field) < 0 && !attr.primaryKey && attr.field !== createdAtAttr);
         const lhsUpdateColumns = _.map(attrsForUpdate, attr => `"${attr.field}"`).join(',');
-        const rhsUpdateColumns = _.map(attrsForUpdate, attr => `EXCLUDED."${attr.field}"`).join(',');
+        const rhsUpdateColumns = _.map(attrsForUpdate, attr => {
+            if (attr.field === '_changes')
+                return `jsonb_deep_merge(${this.tableName}."_changes"::jsonb, EXCLUDED."_changes"::jsonb)`;
+            return `EXCLUDED."${attr.field}"`;
+        }).join(',');
 
         // attributes being inserted
         const attrsForInsert = _.filter(attributes, attr => options.omit.indexOf(attr.field) < 0);


### PR DESCRIPTION
Changes on conflict behaviour for _changes and data field. Allows for merging of _changes objects instead of replacement. The conflict properties have priority for example:

```
original:
{
  working: true,
  walking: false,
 }

 conflict:
 {
  working: false
 }

 will result in :
 {
  working: false,
  walking: false
 }
 instead of:
 {
  working: false
 }
```

 I had to add a deep merge postgres function to do merge the conflict fields. I added it in migration to the paired pr, but it should most likely be moved to this one. Here is the function if you need to add it for testing:

```
 CREATE OR REPLACE FUNCTION jsonb_deep_merge(original jsonb, current jsonb)
             RETURNS JSONB LANGUAGE SQL AS $$
             SELECT
             jsonb_object_agg(
                 coalesce(oKey, cKey),
                 case
                     WHEN oValue isnull THEN cValue
                     WHEN cValue isnull THEN oValue
                     WHEN jsonb_typeof(oValue) <> 'object' or jsonb_typeof(cValue) <> 'object' THEN cValue
                     ELSE jsonb_recursive_merge(oValue, cValue) END
                 )
             FROM jsonb_each(original) e1(oKey, oValue)
             FULL JOIN jsonb_each(current) e2(cKey, cValue) ON oKey = cKey
         $$;
```