### PR TITLE
i5-4920 Semicolon in dataset definition prevents edit.

### DIFF
--- a/lib/upsert-plugin.js
+++ b/lib/upsert-plugin.js
@@ -65,7 +65,8 @@ module.exports = function patchUpsert(sequelize) {
 
     sequelize.queryInterface.QueryGenerator.pgUpsertQuery = function (instance, tableName, insertValues, updateValues, options) {
         const rawAttributes = instance.Model.rawAttributes;
-        const [insertQuery] = this.insertQuery(tableName, insertValues, rawAttributes).split(';');
+        let insertQuery = this.insertQuery(tableName, insertValues, rawAttributes);
+        insertQuery = insertQuery.substring(0, insertQuery.lastIndexOf(';'));
         const updateQuery = _(updateValues).map((value, field) => {
             if (rawAttributes[field].onConflict === 'DEEP_MERGE' || rawAttributes[field].fieldName === 'settings') {
                 const merge = `jsonb_deep_merge(${instance.Model.tableName}."${rawAttributes[field].fieldName}", ${this.escape(value, rawAttributes[field], {context: 'UPDATE'})})`;


### PR DESCRIPTION
pgupsert was calling .split(';') to remove the semicolon at the end of the insertQuery string, but if there was another semicolon a tablename or value it would cut off the rest of the query. Changed logic to slice the string right before the last semicolon.