### PR TITLE
Allow array of 'scope' values in db.* handler configs

### DIFF
--- a/lib/lookup-handler.js
+++ b/lib/lookup-handler.js
@@ -15,7 +15,7 @@ var internals = {};
  * @param {Object} request the hapi request
  * @param {Object} query the compiled query options to be sent to sequelize
  */
-internals.defaultPreLookup = function(request, query) {
+internals.defaultPreLookup = function (request, query) {
 };
 
 /**
@@ -25,14 +25,14 @@ internals.defaultPreLookup = function(request, query) {
  * @param {Object} result the found entity
  * @param {Object} reply the hapi reply
  */
-internals.defaultPostLookup = function(request, result, reply) {
+internals.defaultPostLookup = function (request, result, reply) {
 };
 
 /**
  * Default where builder implementation
  * @param {Object} request the hapi request
  */
-internals.defaultWhere = function(request) {
+internals.defaultWhere = function (request) {
     return request.params;
 };
 
@@ -42,7 +42,7 @@ internals.defaultWhere = function(request) {
  * @param {Object} Model the sequelize model
  * @return {Array}
  */
-internals.defaultRequiredExpansions = function(request, Model) {
+internals.defaultRequiredExpansions = function (request, Model) {
     return [];
 };
 
@@ -66,7 +66,7 @@ internals.optionsSchema = function (sequelize) {
         }).default({ required: internals.defaultRequiredExpansions }),
         preLookup: joi.func().default(internals.defaultPreLookup),
         postLookup: joi.func().default(internals.defaultPostLookup),
-        scope: joi.alternatives([ joi.string(), joi.func() ]).allow(null),
+        scope: joi.alternatives([joi.string(), joi.func(), joi.array().items(joi.string())]).allow(null),
         options: joi.object().default({}),
     };
 };
@@ -76,7 +76,7 @@ internals.optionsSchema = function (sequelize) {
  * @param Model
  * @param options
  */
-internals.routeQuerySchema = function(Model, options) {
+internals.routeQuerySchema = function (Model, options) {
     var schema = {};
 
     var associations = options.expand.valid || Object.keys(Model.associations || {});
@@ -99,7 +99,7 @@ internals.routeQuerySchema = function(Model, options) {
  * @param {Object} options the route options
  * @return {Object} the combined joi schema
  */
-internals.mergeRouteValidationSchemas = function(schemas, Model, options) {
+internals.mergeRouteValidationSchemas = function (schemas, Model, options) {
     var querySchema = internals.routeQuerySchema(Model, options);
 
     schemas = _.merge({}, schemas);
@@ -122,7 +122,7 @@ internals.getIncludes = function (req, Model, options) {
 
     return []
         .concat(options.expand.required(req, Model))
-        .concat(expansions.map(function(expansion) {
+        .concat(expansions.map(function (expansion) {
             return Model.associations[expansion];
         }));
 };
@@ -134,7 +134,7 @@ internals.getIncludes = function (req, Model, options) {
  * @param {Object} options the route options
  * @return {{ where: *, include: []= }} the query options
  */
-internals.queryOptions = function(req, Model, options) {
+internals.queryOptions = function (req, Model, options) {
     var queryOpts = { where: options.where(req) };
 
     var includes = internals.getIncludes(req, Model, options);
@@ -149,15 +149,15 @@ internals.queryOptions = function(req, Model, options) {
  * @param options
  * @return {*}
  */
-internals.processValidatedOptions = function(Model, options) {
+internals.processValidatedOptions = function (Model, options) {
     // compose a function out of array literals
     var required = options.expand.required;
     if (_.isArray(required)) {
-        required = required.map(function(association) {
+        required = required.map(function (association) {
             return Model.associations[association];
         });
         // options.expand.required = () => required    some day :(
-        options.expand.required = function() {
+        options.expand.required = function () {
             return required;
         };
     }
@@ -174,7 +174,7 @@ internals.processValidatedOptions = function(Model, options) {
  * @param route
  * @param options
  */
-internals.createHandler = function(sequelize, route, options) {
+internals.createHandler = function (sequelize, route, options) {
     var Model;
 
     joi.validate(options, internals.optionsSchema(sequelize), function (err, validated) {
@@ -189,35 +189,39 @@ internals.createHandler = function(sequelize, route, options) {
     // combine joi schemas or apply the default query schema
     route.settings.validate = internals.mergeRouteValidationSchemas(route.settings.validate, Model, options);
 
-    return function(req, reply) {
+    return function (req, reply) {
+        let scope = _.isFunction(options.scope) ? options.scope(req) : options.scope;
+        // non-null/undefined -> force array
+        scope = (scope !== null && scope !== undefined) ? [].concat(scope) : scope;
+
         var ScopedModel = options.hasOwnProperty('scope') ?
-            Model.scope(_.isFunction(options.scope) ? options.scope(req) : options.scope) :
+            Model.scope(scope) :
             Model;
 
         // compile the options
         Sequelize.Promise.try(() => internals.queryOptions(req, ScopedModel, options))
 
-            // tweak the options if necessary before querying
+        // tweak the options if necessary before querying
             .tap(options.preLookup.bind(null, req))
 
             // invoke the model finder
-            .then(function(options) {
+            .then(function (options) {
                 return ScopedModel.find(options);
             })
 
             // possible 404
-            .then(function(instance) {
+            .then(function (instance) {
                 if (!instance) throw boom.notFound();
 
                 return instance;
             })
 
             // tweak the output
-            .tap(function(instance) {
+            .tap(function (instance) {
                 return options.postLookup(req, instance, reply);
             })
 
-            .then(function(instance) {
+            .then(function (instance) {
                 process.nextTick(function () {
                     if (!req.response) reply(null, instance);
                 });

--- a/lib/query-handler.js
+++ b/lib/query-handler.js
@@ -14,7 +14,7 @@ var internals = {};
  * @param {Object} request the hapi request
  * @param {Object} query the compiled query options to be sent to sequelize
  */
-internals.defaultPreQuery = function(request, query) {
+internals.defaultPreQuery = function (request, query) {
 };
 
 /**
@@ -23,14 +23,14 @@ internals.defaultPreQuery = function(request, query) {
  * @param {Object} request the hapi request
  * @param {{start: number, total: number, count: number, items: Object[]}} result the collection object
  */
-internals.defaultPostQuery = function(request, result) {
+internals.defaultPostQuery = function (request, result) {
 };
 
 /**
  * Default where builder implementation
  * @param {Object} request the hapi request
  */
-internals.defaultWhere = function(request) {
+internals.defaultWhere = function (request) {
     return Object.keys(request.params).length > 0 ? request.params : null;
 };
 
@@ -40,7 +40,7 @@ internals.defaultWhere = function(request) {
  * @param {Object} Model the sequelize model
  * @return {Array}
  */
-internals.defaultRequiredExpansions = function(request, Model) {
+internals.defaultRequiredExpansions = function (request, Model) {
     return [];
 };
 
@@ -66,7 +66,7 @@ internals.optionsSchema = function (sequelize, defaults) {
             valid: joi.array().items(joi.string()).single(),
             invalid: joi.array().items(joi.string()).single()
         }).default({ required: internals.defaultRequiredExpansions }),
-        scope: joi.alternatives([ joi.string(), joi.func() ]).allow(null),
+        scope: joi.alternatives([joi.string(), joi.func(), joi.array().items(joi.string())]).allow(null),
         options: joi.object().default({}),
         queryOptions: joi.object().default({}),
         preQuery: joi.func().default(internals.defaultPreQuery),
@@ -79,7 +79,7 @@ internals.optionsSchema = function (sequelize, defaults) {
  * @param Model
  * @param options
  */
-internals.routeQuerySchema = function(Model, options) {
+internals.routeQuerySchema = function (Model, options) {
     // [ 'field1', '-field1', ...]
     var sorts = _.keys(Model.attributes).reduce(function (acc, field) {
         acc.push(field);
@@ -118,7 +118,7 @@ internals.routeQuerySchema = function(Model, options) {
  * @param {Object} options the route options
  * @return {Object} the combined joi schema
  */
-internals.mergeRouteValidationSchemas = function(schemas, Model, options) {
+internals.mergeRouteValidationSchemas = function (schemas, Model, options) {
     var querySchema = internals.routeQuerySchema(Model, options);
 
     schemas = _.merge({}, schemas);
@@ -134,7 +134,7 @@ internals.mergeRouteValidationSchemas = function(schemas, Model, options) {
  * @param {Object} options the route options
  * @return {*}
  */
-internals.where = function(req, options) {
+internals.where = function (req, options) {
     var subQuery;
 
     // this function is always valid but may return null to indicate no criteria
@@ -167,7 +167,7 @@ internals.getIncludes = function (req, Model, options) {
 
     return []
         .concat(options.expand.required(req, Model))
-        .concat(expansions.map(function(expansion) {
+        .concat(expansions.map(function (expansion) {
             return Model.associations[expansion];
         }));
 };
@@ -179,7 +179,7 @@ internals.getIncludes = function (req, Model, options) {
  * @param {Object} options the route options
  * @return {{}} the query options
  */
-internals.queryOptions = function(req, Model, options) {
+internals.queryOptions = function (req, Model, options) {
     var queryOpts = { offset: req.query.start };
 
     // only assign the where if not null
@@ -191,10 +191,10 @@ internals.queryOptions = function(req, Model, options) {
 
     // coerce '-username' into ['username', 'DESC']
     var order = req.query.sort.map(function (field) {
-        return field.charAt(0) === '-' ? [[field.substring(1), 'DESC']] : [[ field, 'ASC' ]];
+        return field.charAt(0) === '-' ? [[field.substring(1), 'DESC']] : [[field, 'ASC']];
     });
 
-    if (order.length > 0 ) queryOpts.order = order;
+    if (order.length > 0) queryOpts.order = order;
 
     // 0 disables limit
     if (req.query.limit > 0) queryOpts.limit = req.query.limit;
@@ -211,15 +211,15 @@ internals.queryOptions = function(req, Model, options) {
  * @param options
  * @return {*}
  */
-internals.processValidatedOptions = function(Model, options) {
+internals.processValidatedOptions = function (Model, options) {
     // compose a function out of array literals
     var required = options.expand.required;
     if (_.isArray(required)) {
-        required = required.map(function(association) {
+        required = required.map(function (association) {
             return Model.associations[association];
         });
         // options.expand.required = () => required    some day :(
-        options.expand.required = function() {
+        options.expand.required = function () {
             return required;
         };
     }
@@ -238,7 +238,7 @@ internals.processValidatedOptions = function(Model, options) {
  * @param route
  * @param routeOptions
  */
-internals.createHandler = function(sequelize, defaults, route, routeOptions) {
+internals.createHandler = function (sequelize, defaults, route, routeOptions) {
     var Model, validated;
 
     joi.validate(routeOptions, internals.optionsSchema(sequelize, defaults), function (err, validated) {
@@ -253,19 +253,23 @@ internals.createHandler = function(sequelize, defaults, route, routeOptions) {
     // combine joi schemas or apply the default query schema
     route.settings.validate = internals.mergeRouteValidationSchemas(route.settings.validate, Model, routeOptions);
 
-    return function(req, reply) {
+    return function (req, reply) {
+        let scope = _.isFunction(routeOptions.scope) ? routeOptions.scope(req) : routeOptions.scope;
+        // non-null/undefined -> force array
+        scope = (scope !== null && scope !== undefined) ? [].concat(scope) : scope;
+
         var ScopedModel = routeOptions.hasOwnProperty('scope') ?
-            Model.scope(_.isFunction(routeOptions.scope) ? routeOptions.scope(req) : routeOptions.scope) :
+            Model.scope(scope) :
             Model;
 
         // compile the options
         Sequelize.Promise.try(() => internals.queryOptions(req, ScopedModel, routeOptions))
 
-            // tweak the options if necessary before querying
+        // tweak the options if necessary before querying
             .tap(routeOptions.preQuery.bind(null, req))
 
             // invoke the model finder
-            .then(function(options) {
+            .then(function (options) {
                 return ScopedModel.findAndCountAll(options, routeOptions.queryOptions);
             })
 

--- a/lib/remove-handler.js
+++ b/lib/remove-handler.js
@@ -21,7 +21,7 @@ internals.defaultWhere = function (request) {
  * @param {Object} request the hapi request
  * @param {Object} options the delete options to pass to sequelize
  */
-internals.defaultPreDelete = function(request, options) {
+internals.defaultPreDelete = function (request, options) {
 
 };
 
@@ -32,7 +32,7 @@ internals.defaultPreDelete = function(request, options) {
  * @param {Object} request the hapi request
  * @param result the result of the delete operation
  */
-internals.defaultPostDelete = function(request, result) {
+internals.defaultPostDelete = function (request, result) {
 
 };
 
@@ -50,7 +50,7 @@ internals.optionsSchema = function (sequelize) {
         options: joi.object().default({}),
         preRemove: joi.func().default(internals.defaultPreDelete),
         postRemove: joi.func().default(internals.defaultPostDelete),
-        scope: joi.alternatives([ joi.string(), joi.func() ]).allow(null)
+        scope: joi.alternatives([joi.string(), joi.func(), joi.array().items(joi.string())]).allow(null)
     });
 };
 
@@ -60,7 +60,7 @@ internals.optionsSchema = function (sequelize) {
  * @param {Object} options the route options
  * @returns {Object} the where clause object
  */
-internals.buildWhere = function(req, options) {
+internals.buildWhere = function (req, options) {
     return options.where(req);
 };
 
@@ -70,7 +70,7 @@ internals.buildWhere = function(req, options) {
  * @param {Object} options the route options
  * @returns {Object} the delete options for sequelize
  */
-internals.constructDeleteOptions = function(req, options) {
+internals.constructDeleteOptions = function (req, options) {
     // to fire the pre/postDestroy methods on individual models
     // can be overridden in the route options
     var opts = { individualHooks: true };
@@ -107,15 +107,19 @@ internals.createHandler = function (sequelize, defaults, route, options) {
     Model = sequelize.models[options.model];
 
     return function (req, reply) {
+        let scope = _.isFunction(options.scope) ? options.scope(req) : options.scope;
+        // non-null/undefined -> force array
+        scope = (scope !== null && scope !== undefined) ? [].concat(scope) : scope;
+
         var ScopedModel = options.hasOwnProperty('scope') ?
-            Model.scope(_.isFunction(options.scope) ? options.scope(req) : options.scope) :
+            Model.scope(scope) :
             Model;
 
         //require the operation to always be in a transaction
         return sequelize.requiresTransaction(function (t) {
             //construct the options
             return Sequelize.Promise.try(() => internals.constructDeleteOptions(req, options))
-                //hook in if options need tweaking
+            //hook in if options need tweaking
                 .tap(options.preRemove.bind(null, req))
                 //perform the delete, always passing the transaction along
                 .then(function (opts) {
@@ -125,7 +129,7 @@ internals.createHandler = function (sequelize, defaults, route, options) {
                 //in case something needs to happen after the delete
                 .tap(options.postRemove.bind(null, req))
                 //never return anything from http DELETE method
-                .then(function(){
+                .then(function () {
                     reply();
                 })
                 //catch anything that went wrong

--- a/lib/update-handler.js
+++ b/lib/update-handler.js
@@ -50,7 +50,7 @@ internals.defaultWhere = function (request) {
 };
 
 /**
- * Options schema to validate 
+ * Options schema to validate
  * @param sequelize Sequelize object
  * @returns {{model: *, where: *, preUpdate: *, postUpdate: *}} options object with defaults for undefined attributes
  */
@@ -64,12 +64,12 @@ internals.optionsSchema = function (sequelize) {
         postCreate: joi.func().default(internals.defaultPostCreate),
         create: joi.boolean().default(false),
         options: joi.object(),
-        scope: joi.alternatives([ joi.string(), joi.func() ]).allow(null)
+        scope: joi.alternatives([joi.string(), joi.func(), joi.array().items(joi.string())]).allow(null)
     };
 };
 
 /**
- * Creates generic update handler 
+ * Creates generic update handler
  * @param sequelize Sequelize object
  * @param route Route to handle
  * @param options Options object
@@ -80,22 +80,26 @@ internals.createHandler = function (sequelize, route, options) {
         if (err) throw new Error('Error in route ' + route.path + ': ' + err.message);
         options = validated;
     });
-    
+
     var Model = sequelize.model(options.model);
     var newInstance = false;
 
     return function (req, reply) {
+        let scope = _.isFunction(options.scope) ? options.scope(req) : options.scope;
+        // non-null/undefined -> force array
+        scope = (scope !== null && scope !== undefined) ? [].concat(scope) : scope;
+
         var ScopedModel = options.hasOwnProperty('scope') ?
-            Model.scope(_.isFunction(options.scope) ? options.scope(req) : options.scope) :
+            Model.scope(scope) :
             Model;
 
         var where = options.where(req);
-        
+
         if (!where || Object.keys(where).length === 0) {
             //If no where conditions are defined at all then findOne() would return an unpredictable result.
             throw Boom.badRequest('Request has no conditions. Results would be indeterminate.');
         }
-        
+
         //Perform find and update within a transaction
         return sequelize.requiresTransaction(function (t) {
             return ScopedModel.findOne({ where: where, transaction: t })
@@ -114,17 +118,17 @@ internals.createHandler = function (sequelize, route, options) {
                     instance.set(_.assign({}, req.payload));
                     return instance;
                 })
-                .tap(function(instance) {
+                .tap(function (instance) {
                     newInstance = instance.isNewRecord;
                     return newInstance ? options.preCreate(req, instance) : options.preUpdate(req, instance)
                 })
-                .then(function(instance) {
+                .then(function (instance) {
                     return instance.save(_.assign({}, options.options, { transaction: t }));
                 })
-                .tap(function(instance) {
+                .tap(function (instance) {
                     return newInstance ? options.postCreate(req, instance, reply) : options.postUpdate(req, instance, reply);
                 })
-                .then(function(instance) {
+                .then(function (instance) {
                     process.nextTick(function () {
                         if (!req.response) reply(null, instance);
                     });

--- a/test/lib/bulk-upsert-plugin-spec.js
+++ b/test/lib/bulk-upsert-plugin-spec.js
@@ -15,6 +15,8 @@ const P = sequelize.Sequelize.Promise;
 
 describe('bulk upsert plugin', function () {
 
+    // NOTE: this test now only works if jsonb_deep_merge function exists
+
     describe('.bulkUpsertStream()', function () {
 
         it('should add the function to the prototype of Model', function () {

--- a/test/lib/query-handler-spec.js
+++ b/test/lib/query-handler-spec.js
@@ -399,6 +399,17 @@ describe('QueryHandler', function () {
                 }
             }).should.not.throw();
         });
+
+        it(`should support a scope option that is an array of strings`, () => {
+            addRoute.bind(null, {
+                handler: {
+                    'db.query': {
+                        model: 'User',
+                        scope: ['scope_one', 'scope_two']
+                    }
+                }
+            }).should.not.throw();
+        });
     });
 
     describe('route handler', function () {
@@ -783,7 +794,7 @@ describe('QueryHandler', function () {
             })
                 .then(res => {
                     res.statusCode.should.equal(200);
-                    scope.should.have.been.calledWith('customScope');
+                    scope.should.have.been.calledWith(['customScope']);
                 });
         });
 
@@ -830,6 +841,28 @@ describe('QueryHandler', function () {
                     res.statusCode.should.equal(200);
                     handlerScopeSpy.should.have.been.calledOnce;
                     handlerScopeSpy.firstCall.args.should.have.length(1);
+                });
+        });
+
+        it(`should use a configured scope array of scope names`, () => {
+            server.route({
+                method: 'get',
+                path: '/users',
+                handler: {
+                    'db.query': {
+                        model: 'User',
+                        scope: ['scope_one', 'scope_two']
+                    }
+                }
+            });
+
+            return server.injectThen({
+                method: 'GET',
+                url: '/users'
+            })
+                .then(res => {
+                    res.statusCode.should.equal(200);
+                    scope.should.have.been.calledWith(['scope_one', 'scope_two']);
                 });
         });
 

--- a/test/lib/update-handler-spec.js
+++ b/test/lib/update-handler-spec.js
@@ -36,7 +36,7 @@ describe('Generic Update Handler', function () {
                 save: saver,
                 isNewRecord: false
             };
-            
+
             return Sequelize.Promise.resolve(instance);
         });
 
@@ -96,7 +96,7 @@ describe('Generic Update Handler', function () {
     });
 
     var addRoute = function (cfg) {
-        server.route({path: '/users/{username}', method: 'put', config: _.assign(cfg, {id: 'user.update'})});
+        server.route({ path: '/users/{username}', method: 'put', config: _.assign(cfg, { id: 'user.update' }) });
     };
 
     describe('registration', function () {
@@ -156,7 +156,7 @@ describe('Generic Update Handler', function () {
                 handler: {
                     'db.update': {
                         model: 'User',
-                        where: {foo: 'bar'}
+                        where: { foo: 'bar' }
                     }
                 }
             }).should.throw('Error in route /users/{username}: child "where" fails because ["where" must be a Function]');
@@ -231,7 +231,7 @@ describe('Generic Update Handler', function () {
         });
 
         it('should return a handler function when invoked', function () {
-            factory(sequelize, {model: 'User'}).should.be.a('function');
+            factory(sequelize, { model: 'User' }).should.be.a('function');
         });
 
         it('should support a scope option', function () {
@@ -266,6 +266,17 @@ describe('Generic Update Handler', function () {
                 }
             }).should.not.throw();
         });
+
+        it(`should support a scope option that is an array of strings`, () => {
+            addRoute.bind(null, {
+                handler: {
+                    'db.update': {
+                        model: 'User',
+                        scope: ['scope_one', 'scope_two']
+                    }
+                }
+            }).should.not.throw();
+        });
     });
 
     describe('handler', function () {
@@ -288,12 +299,12 @@ describe('Generic Update Handler', function () {
                 }
             }).then(function (res) {
                 res.statusCode.should.equal(200);
-                finder.should.have.been.calledWith({ transaction: undefined, where: {username: 'robert'} });
+                finder.should.have.been.calledWith({ transaction: undefined, where: { username: 'robert' } });
                 saver.firstCall.thisValue.should.have.property('username', 'robert');
                 saver.firstCall.thisValue.should.have.property('change', 'changeit');
             });
         });
-        
+
         it('should require parameters', function () {
             server.route({
                 method: 'put',
@@ -325,7 +336,7 @@ describe('Generic Update Handler', function () {
                         'db.update': {
                             model: 'User',
                             where: function (req) {
-                                return {username: req.query.username};
+                                return { username: req.query.username };
                             }
                         }
                     },
@@ -345,7 +356,7 @@ describe('Generic Update Handler', function () {
                 }
             }).then(function (res) {
                 res.statusCode.should.equal(200);
-                finder.should.have.been.calledWith({ transaction: undefined, where: {username: 'robert'} });
+                finder.should.have.been.calledWith({ transaction: undefined, where: { username: 'robert' } });
                 saver.firstCall.thisValue.should.have.property('username', 'robert');
                 saver.firstCall.thisValue.should.have.property('change', 'changeit');
             });
@@ -420,7 +431,7 @@ describe('Generic Update Handler', function () {
                     'db.update': {
                         model: 'Bar',
                         create: true,
-                        postCreate: function(req, instance, reply) {
+                        postCreate: function (req, instance, reply) {
                             reply(instance).created('/bars/snookerz');
                         }
                     }
@@ -507,7 +518,7 @@ describe('Generic Update Handler', function () {
             })
                 .then(res => {
                     res.statusCode.should.equal(200);
-                    scope.should.have.been.calledWith('customScope');
+                    scope.should.have.been.calledWith(['customScope']);
                 });
         });
 
@@ -554,6 +565,28 @@ describe('Generic Update Handler', function () {
                     res.statusCode.should.equal(200);
                     handlerScopeSpy.should.have.been.calledOnce;
                     handlerScopeSpy.firstCall.args.should.have.length(1);
+                });
+        });
+
+        it(`should use a configured scope array of scope names`, () => {
+            server.route({
+                method: 'put',
+                path: '/users/{userId}',
+                handler: {
+                    'db.update': {
+                        model: 'User',
+                        scope: ['scope_one', 'scope_two']
+                    }
+                }
+            });
+
+            return server.injectThen({
+                method: 'put',
+                url: '/users/me'
+            })
+                .then(res => {
+                    res.statusCode.should.equal(200);
+                    scope.should.have.been.calledWith(['scope_one', 'scope_two']);
                 });
         });
 


### PR DESCRIPTION
- can now specify an array multiple 'scope' values in db.* handlers
- updated/added mocha tests