### PR TITLE
Adds support for automatically retrying transactions that fail due to concurrent updates

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -113,7 +113,7 @@ exports.requiresTransaction = function (sequelize, fn) {
     return sequelize.transaction(fn);
 };
 
-exports.retryTransaction = function (sequelize, fn, opts) {
+exports.sideEffectFreeTransaction = function (sequelize, fn, opts = { max: 3, match: 'could not serialize access due to concurrent update'}) {
     return retryAsPromised(() => {
         return sequelize.transaction(fn);
     }, opts);
@@ -125,9 +125,9 @@ exports.enableRequiresTransaction = function () {
     };
 };
 
-exports.enableRetryTransaction = function() {
-    Sequelize.prototype.retryTransaction = function (fn, opts) {
-        return exports.retryTransaction(this, fn, opts);
+exports.enableSideEffectFreeTransaction = function() {
+    Sequelize.prototype.sideEffectFreeTransaction = function (fn, opts) {
+        return exports.sideEffectFreeTransaction(this, fn, opts);
     };
 };
 
@@ -275,7 +275,7 @@ exports.register = async function (server, opts, next) {
     // adds requiresTransaction() method to sequelize
     exports.enableRequiresTransaction();
 
-    exports.enableRetryTransaction();
+    exports.enableSideEffectFreeTransaction();
 
     // turn on lobs
     exports.enableLobSupport();

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,6 +8,8 @@ const lookupHandler = require('./lookup-handler');
 const queryHandler = require('./query-handler');
 const removeHandler = require('./remove-handler');
 const updateHandler = require('./update-handler');
+const retryAsPromised = require('retry-as-promised');
+
 const ADVISORY_LOCK = 314159265;
 
 exports.associate = function associate (sequelize) {
@@ -111,9 +113,21 @@ exports.requiresTransaction = function (sequelize, fn) {
     return sequelize.transaction(fn);
 };
 
+exports.retryTransaction = function (sequelize, fn, opts) {
+    return retryAsPromised(() => {
+        return sequelize.transaction(fn);
+    }, opts);
+};
+
 exports.enableRequiresTransaction = function () {
     Sequelize.prototype.requiresTransaction = function (fn) {
         return exports.requiresTransaction(this, fn);
+    };
+};
+
+exports.enableRetryTransaction = function() {
+    Sequelize.prototype.retryTransaction = function (fn, opts) {
+        return exports.retryTransaction(this, fn, opts);
     };
 };
 
@@ -260,6 +274,8 @@ exports.register = async function (server, opts, next) {
 
     // adds requiresTransaction() method to sequelize
     exports.enableRequiresTransaction();
+
+    exports.enableRetryTransaction();
 
     // turn on lobs
     exports.enableLobSupport();

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
         "moniker": "^0.1.2",
         "pg-copy-streams": "^1.2.0",
         "pg-large-object": "1.0.1",
+        "retry-as-promised": "^3.2.0",
         "sequelize": "3.27.x",
         "slug": "^0.9.1"
     }


### PR DESCRIPTION
Paired PR for https://github.com/entrinsik-org/i5/pull/4149

note: i would prefer to check for concurrent update exception by its code (40001) but, sadly, i see no way to do this with the retry-as-promised library.