### PR TITLE
Workaround for including HasMany association with separate:true + attributes[]

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -125,7 +125,7 @@ exports.enableRequiresTransaction = function () {
     };
 };
 
-exports.enableSideEffectFreeTransaction = function() {
+exports.enableSideEffectFreeTransaction = function () {
     Sequelize.prototype.sideEffectFreeTransaction = function (fn, opts) {
         return exports.sideEffectFreeTransaction(this, fn, opts);
     };
@@ -182,11 +182,17 @@ exports.ensureDeepJsonbMerge = function (sequelize) {
  * defaulted into an include entry of a Model.find() call; the 'separate' config is only honored
  * when it is explicitly provided to the specific includes entry.
  *
+ * This also works around a sequelize issue where sequelize can break outright if 'separate' option and an explicit
+ * attributes collection are provided for an included HasMany but the foreignKey of the association is not one of them.
+ * This particular issue was fixed in sequelize by https://github.com/sequelize/sequelize/pull/9396 and published
+ * in 5.0.0-beta.5 and generally available in sequelize@>=5.1.0
+ *
  * @param sequelize a sequelize instance
  */
 exports.separateHasManyAssociationHook = function (sequelize) {
     // add global 'beforeFindAfterExpandIncludeAll' sequelize hook to bubble up existing 'separate' config on
-    // included HasMany associations and default to 'separate:true' if not explicitly configured on the included HasMany associations.
+    // included HasMany associations and default to 'separate:true' if not explicitly configured on the included HasMany associations
+    // and also add the foreignKey attributes of the included HasMany association if not provided already.
     // Must occur before 'separate' includes are processed so PK attributes from separate includes get added properly
     // during Model.$validateIncludedElements
     const HasMany = sequelize.Association.HasMany;
@@ -202,9 +208,15 @@ exports.separateHasManyAssociationHook = function (sequelize) {
             // convert direct HasMany association reference to include object structure, carrying over 'separate' config from the association or default to true
             if (include instanceof HasMany) return makeIncludeObject(include);
 
-            if (include.association instanceof HasMany && !include.hasOwnProperty('separate')) {
-                // default in 'separate' config from HasMany association
-                include.separate = _.get(include.association, ['options', 'separate']);
+            if (include.association instanceof HasMany) {
+                // default in 'separate' config from HasMany association if 'separate' option not explicitly provided
+                if (!include.hasOwnProperty('separate')) {
+                    include.separate = _.get(include.association, ['options', 'separate']);
+                }
+                // ensure 'separate' HasMany association foreignKey is in include.attributes, when attributes are explicitly provided. Otherwise, error happens in Model.$findSeparate() -> HasMany.get() when merging results @ ~331
+                if (include.separate && _.get(include, ['attributes', 'length']) && !_.includes(_.flattenDeep(include.attributes), include.association.foreignKey)) {
+                    include.attributes.push(include.association.foreignKey);
+                }
             } else if (!include.association && _.get(include.model, ['scoped']) && include.model.$scope) {
                 // otherwise when no association is provided but the include references scoped model, process scoped model includes
                 include.model.$scope = separateHasMany(include.model.$scope);

--- a/test/lib/separate-has-many-association-hook-spec.js
+++ b/test/lib/separate-has-many-association-hook-spec.js
@@ -1,0 +1,86 @@
+'use strict';
+
+const $ = require('./common');
+const { should, sinon, models } = $;
+const { SourceModel, TargetModel } = models;
+
+describe(`separateHasManyAssociationHook`, () => {
+    let source, targets, querySpy;
+
+    beforeEach(async () => {
+        source = await SourceModel.create({
+            sourceData: 'source data 0',
+            name: 'Source Number 0',
+            config: { foo: 'bar' }
+        });
+        targets = await TargetModel.bulkCreate([
+            { targetData: 'target data 0', name: 'Target Number 0', sourceId: source.id, data: { bar: 'baz' } },
+            { targetData: 'target data 1', name: 'Target Number 1', sourceId: source.id, data: { foo: 1 } },
+            { targetData: 'target data 2', name: 'Target Number 2', sourceId: source.id, data: { real: false } },
+            { targetData: 'target data 3', name: 'Target Number 3', data: { treez: 'fireproof' } }
+        ]);
+        querySpy = sinon.spy();
+    });
+
+    describe(`when an 'include' has no 'separate' config (inherited from association)`, () => {
+        it(`should inherit the 'separate' config from the HasMany association automatically and execute N queries`, async () => {
+            let result, error;
+            try {
+                result = await SourceModel.find({
+                    where: {
+                        id: source.id
+                    },
+                    include: { association: SourceModel.associations.targetModels, attributes: ['targetData'] },
+                    logging: querySpy
+                });
+            } catch (err) {
+                error = err;
+            }
+            should.not.exist(error);
+            should.exist(result);
+            querySpy.should.have.been.calledTwice;
+        });
+
+        it(`should not break when an included association provides explicit attributes that do not include the association's foreignKey`, async () => {
+            let result, error;
+            try {
+                result = await SourceModel.find({
+                    where: {
+                        id: source.id
+                    },
+                    include: { association: SourceModel.associations.targetModels, attributes: ['targetData'] },
+                    logging: querySpy
+                });
+            } catch (err) {
+                error = err;
+            }
+            should.not.exist(error);
+            should.exist(result);
+            querySpy.should.have.been.calledTwice;
+            result.should.have.property('targetModels').that.is.an('Array').that.has.length(3);
+            result.targetModels.map(t => t.get()).forEach(t => t.should.have.property('targetData'));
+        });
+    });
+
+    describe(`when an 'include' explicitly provides 'separate: true'`, () => {
+        it(`should not break when an included association provides explicit attributes that do not include the association's foreignKey`, async () => {
+            let result, error;
+            try {
+                result = await SourceModel.find({
+                    where: {
+                        id: source.id
+                    },
+                    include: { association: SourceModel.associations.targetModels, attributes: ['targetData'], separate: true },
+                    logging: querySpy
+                });
+            } catch (err) {
+                error = err;
+            }
+            should.not.exist(error);
+            should.exist(result);
+            querySpy.should.have.been.calledTwice;
+            result.should.have.property('targetModels').that.is.an('Array').that.has.length(3);
+            result.targetModels.map(t => t.get()).forEach(t => t.should.have.property('targetData'));
+        });
+    });
+});

--- a/test/test-models/index.js
+++ b/test/test-models/index.js
@@ -9,6 +9,8 @@ module.exports = _.curry(function (sequelize) {
         TestBaz: require('./test-baz')(sequelize),
         TestBlah: require('./test-blah')(sequelize),
         UpsertModel: require('./upsert-model')(sequelize),
-        MultipartUpsertModel: require('./multipart-upsert-model')(sequelize)
+        MultipartUpsertModel: require('./multipart-upsert-model')(sequelize),
+        SourceModel: require('./source-model')(sequelize),
+        TargetModel: require('./target-model')(sequelize)
     };
 });

--- a/test/test-models/source-model.js
+++ b/test/test-models/source-model.js
@@ -1,0 +1,29 @@
+'use strict';
+
+module.exports = function (sequelize) {
+
+    const DataTypes = sequelize.Sequelize;
+
+    const attributes = {
+        id: { type: DataTypes.UUID, defaultValue: DataTypes.UUIDV4, primaryKey: true },
+        sourceData: DataTypes.STRING,
+        name: DataTypes.STRING,
+        config: DataTypes.JSONB
+    };
+
+    const instanceMethods = {};
+
+    const classMethods = {};
+
+    const options = {
+        tableName: 'source_model',
+        timestamps: true,
+        instanceMethods: instanceMethods,
+        classMethods: classMethods,
+        associate (models) {
+            this.hasMany(models.TargetModel, { as: 'targetModels', foreignKey: 'sourceId', separate: true });
+        }
+    };
+
+    return sequelize.define('SourceModel', attributes, options);
+};

--- a/test/test-models/target-model.js
+++ b/test/test-models/target-model.js
@@ -1,0 +1,26 @@
+'use strict';
+
+module.exports = function (sequelize) {
+
+    const DataTypes = sequelize.Sequelize;
+
+    const attributes = {
+        id: { type: DataTypes.UUID, defaultValue: DataTypes.UUIDV4, primaryKey: true },
+        targetData: DataTypes.STRING,
+        name: DataTypes.STRING,
+        data: DataTypes.JSONB
+    };
+
+    const instanceMethods = {};
+
+    const classMethods = {};
+
+    const options = {
+        tableName: 'target_model',
+        timestamps: true,
+        instanceMethods: instanceMethods,
+        classMethods: classMethods
+    };
+
+    return sequelize.define('TargetModel', attributes, options);
+};


### PR DESCRIPTION
- added workaround to fix issue where sequelize would error out when providing separate:true & explicit attributes[] collection together for a HasMany association in an 'include' entry.
- added associated tests
- added some doc notes about the actual fix in sequelize (which is a version we can't upgrade to yet sequelize@>=5.1.0)

+patch