### PR TITLE
Updated pg-copy-streams to v5.1.1 to catch up the stream impl compliance

### DIFF
--- a/lib/bulk-upsert-plugin.js
+++ b/lib/bulk-upsert-plugin.js
@@ -221,7 +221,7 @@ exports.plugin = {
                         new P((resolve, reject) => {
                             getCsvStream($stream, $copy)
                                 .on('error', err => reject(streamError(err)))
-                                .on('end', () => resolve());
+                                .on('finish', () => resolve());
                         })
                 )
                 .finally(() => $copy.end());

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
         "joi": "^9.0.4",
         "lodash": "^3.9.3",
         "moniker": "^0.1.2",
-        "pg-copy-streams": "^1.2.0",
+        "pg-copy-streams": "^5.1.1",
         "pg-large-object": "1.0.1",
         "retry-as-promised": "^3.2.0",
         "slug": "^0.9.1"

--- a/test/db.js
+++ b/test/db.js
@@ -41,6 +41,8 @@ const sequelize = new Sequelize(config.database, config.user, config.password, {
     dialect: 'postgres'
 });
 su.separateHasManyAssociationHook(sequelize);
+// required for bulk-upsert-plugin tests
+su.ensureDeepJsonbMerge(sequelize);
 
 exports.su = su;
 exports.sequelize = sequelize;


### PR DESCRIPTION
- adjust to fixes where copyFrom is now a Writable and copyTo is now a Readable instead of both improperly being Transforms

+patch